### PR TITLE
Fix earthly star duration

### DIFF
--- a/FightTimeLine/ClientApp/src/core/Jobs/FFXIV/AST.ts
+++ b/FightTimeLine/ClientApp/src/core/Jobs/FFXIV/AST.ts
@@ -62,7 +62,7 @@ export const AST: IJob = {
     },
     {
       name: "Earthly Star",
-      duration: 30,
+      duration: 21,
       cooldown: 60,
       xivDbId: "7439",
       icon: ("23_Astrologian/7439_Earthly Star"),


### PR DESCRIPTION
auto-detonation (i.e. outgoing healing) happens 21 seconds from the cast point, not 30