### PR TITLE
Updates ability xivDbId for SGE job

### DIFF
--- a/FightTimeLine/ClientApp/src/Jobs/FFXIV/SGE.ts
+++ b/FightTimeLine/ClientApp/src/Jobs/FFXIV/SGE.ts
@@ -150,7 +150,7 @@ const abilities = [
     overlapStrategy: new AllowOverlapStrategy(),
     levelAcquired: 30,
     potency: 100,
-    xivDbId: 24292,
+    xivDbId: 37034,
     statuses: [statuses.eprog],
     abilityType: AbilityType.PartyShield,
   },


### PR DESCRIPTION
Changes the xivDbId of a specific ability from 24292 to 37034 to correct the database reference in the SGE job abilities list.

(cherry picked from commit 0bf66a401dce89c8503381c68c9320ca4fc787d7)