### PR TITLE
Updates level requirement for SelfShield ability

### DIFF
--- a/FightTimeLine/ClientApp/src/Jobs/FFXIV/SCH.ts
+++ b/FightTimeLine/ClientApp/src/Jobs/FFXIV/SCH.ts
@@ -198,7 +198,7 @@ const abilities = [
     potency: 360,
     overlapStrategy: new AllowOverlapStrategy(),
     abilityType: AbilityType.SelfShield,
-    levelAcquired: 30,
+    levelAcquired: 100,
   },
   {
     name: "Whispering Dawn",


### PR DESCRIPTION
Changes the level acquired for the SelfShield ability from 30 to 100 to reflect the updated game mechanics.